### PR TITLE
filetype of Image Captcha can be specified

### DIFF
--- a/captcha/image.py
+++ b/captcha/image.py
@@ -31,7 +31,7 @@ else:
 
 
 class _Captcha(object):
-    def generate(self, chars, format='jpeg'):
+    def generate(self, chars, format='png'):
         """Generate an Image Captcha of the given characters.
 
         :param chars: text to be generated.
@@ -43,7 +43,7 @@ class _Captcha(object):
         out.seek(0)
         return out
 
-    def write(self, chars, output, format='jpeg'):
+    def write(self, chars, output, format='png'):
         """Generate and write an image CAPTCHA data to the output.
 
         :param chars: text to be generated.

--- a/captcha/image.py
+++ b/captcha/image.py
@@ -31,25 +31,27 @@ else:
 
 
 class _Captcha(object):
-    def generate(self, chars):
+    def generate(self, chars, format='jpeg'):
         """Generate an Image Captcha of the given characters.
 
         :param chars: text to be generated.
+        :param format: image file format
         """
         im = self.generate_image(chars)
         out = BytesIO()
-        im.save(out, format='png')
+        im.save(out, format=format)
         out.seek(0)
         return out
 
-    def write(self, chars, output):
+    def write(self, chars, output, format='jpeg'):
         """Generate and write an image CAPTCHA data to the output.
 
         :param chars: text to be generated.
         :param output: output destionation.
+        :param format: image file format
         """
         im = self.generate_image(chars)
-        return im.save(output, format='png')
+        return im.save(output, format=format)
 
 
 class WheezyCaptcha(_Captcha):


### PR DESCRIPTION
Although JPEG compression is a loss compression and PNG is non-lossy, the loss of image captcha quality is bearable. The size of JPEG image captcha after default compression by PIL can be much more smaller than PNG. So I suppose add a parameter 'format' which equals to 'jpeg' by default in the function generate & write of class _Captcha can be better. (If someone still want to use PNG or other filetypes……)