### PR TITLE
Fix raised 'TypeError: must be str, not bytearray' when saving audio …

### DIFF
--- a/captcha/audio.py
+++ b/captcha/audio.py
@@ -278,5 +278,5 @@ class AudioCaptcha(object):
         :param output: output destionation.
         """
         data = self.generate(chars)
-        with open(output, 'w') as f:
+        with open(output, 'wb') as f:
             return f.write(data)


### PR DESCRIPTION
…file in Python 3.4.3 on Ubuntu Linux 14.04 system.