### PR TITLE
PIL compatibility

### DIFF
--- a/captcha/image.py
+++ b/captcha/image.py
@@ -131,7 +131,7 @@ class ImageCaptcha(_Captcha):
         x2 = random.randint(w - int(w / 5), w)
         y1 = random.randint(int(h / 5), h - int(h / 5))
         y2 = random.randint(y1, h - int(h / 5))
-        points = [(x1, y1), (x2, y2)]
+        points = [x1, y1, x2, y2]
         end = random.randint(160, 200)
         start = random.randint(0, 20)
         Draw(image).arc(points, start, end, fill=color)


### PR DESCRIPTION
Fixing the `Draw.arc` arguments to make the module compatible with PIL (and therefore Google App Engine, because it doesn't really use Pillow). Pillow [supports](http://pillow.readthedocs.io/en/3.1.x/reference/ImageDraw.html#PIL.ImageDraw.PIL.ImageDraw.Draw.arc) both `[x1, y1, x2, y2]` and `[(x1, y1), (x2, y2)]`, while PIL only supports the former.

Tested with PIL 1.1.7 (latest), the GAE version of PIL (also 1.1.7, I think), and the latest Pillow.