### PR TITLE
Update package init.py to fix failing imports

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,8 +39,8 @@ Audio and Image CAPTCHAs are in seprated modules:
 
 .. code:: python
 
-    from captcha.audio import AudioCaptcha
-    from captcha.image import ImageCaptcha
+    from captcha import AudioCaptcha
+    from captcha import ImageCaptcha
 
     audio = AudioCaptcha(voicedir='/path/to/voices')
     image = ImageCaptcha(fonts=['/path/A.ttf', '/path/B.ttf'])

--- a/README.rst
+++ b/README.rst
@@ -39,8 +39,7 @@ Audio and Image CAPTCHAs are in seprated modules:
 
 .. code:: python
 
-    from captcha import AudioCaptcha
-    from captcha import ImageCaptcha
+    from captcha import AudioCaptcha, ImageCaptcha
 
     audio = AudioCaptcha(voicedir='/path/to/voices')
     image = ImageCaptcha(fonts=['/path/A.ttf', '/path/B.ttf'])

--- a/captcha/__init__.py
+++ b/captcha/__init__.py
@@ -13,3 +13,6 @@
 __version__ = '0.3'
 __author__ = 'Hsiaoming Yang <me@lepture.com>'
 __homepage__ = 'https://github.com/lepture/captcha'
+
+from .audio import AudioCaptcha
+from .image import ImageCaptcha

--- a/captcha/__init__.py
+++ b/captcha/__init__.py
@@ -15,4 +15,4 @@ __author__ = 'Hsiaoming Yang <me@lepture.com>'
 __homepage__ = 'https://github.com/lepture/captcha'
 
 from .audio import AudioCaptcha
-from .image import ImageCaptcha
+from .image import ImageCaptcha, WheezyCaptcha

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-from captcha.audio import AudioCaptcha
+from captcha import AudioCaptcha
 
 
 def test_audio_generate():

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -3,7 +3,7 @@
 import sys
 
 if not hasattr(sys, 'pypy_version_info'):
-    from captcha.image import ImageCaptcha, WheezyCaptcha
+    from captcha import ImageCaptcha, WheezyCaptcha
 
     def test_image_generate():
         captcha = ImageCaptcha()


### PR DESCRIPTION
See https://github.com/lepture/captcha/issues/44 for the full details of the issue I ran into when running the example code and my Python and package specs.

This update would have it so `AudioCaptcha` and `ImageCaptcha` are both exported as part of `__init__.py`.

I confirmed this is working on my end by going into the folder on my computer where pypi packages are stored locally and made this change to the `__init__.py` file.

This change is not backwards compatible, so the next version for this should be for `1.0.0`.