### PR TITLE
Captcha image bug fix

### DIFF
--- a/captcha/image.py
+++ b/captcha/image.py
@@ -174,7 +174,8 @@ class ImageCaptcha(_Captcha):
             try:
                 _, _, w, h = draw.textbbox((1, 1), c, font=font)
             except AttributeError:
-                w, h = draw.textsize(c, font=font)
+                w, h = draw.textbbox((1, 1), c, font=font)[2:]
+                ## BUG FIX AFTER THE NEW PILLOW RELEASE
 
             dx = random.randint(0, 4)
             dy = random.randint(0, 6)


### PR DESCRIPTION
After recent new release of the pillow version 10.0.0, captcha has been throwing errors,  I looked up the error and found out they have sort of discontinued the .textsize() method,  I suggest the following changes, 
this works on my local machine, error free.