### PR TITLE
typing for font_sizes in image captcha is fixed

### DIFF
--- a/src/captcha/image.py
+++ b/src/captcha/image.py
@@ -51,7 +51,7 @@ class ImageCaptcha:
             width: int = 160,
             height: int = 60,
             fonts: t.Optional[t.List[str]] = None,
-            font_sizes: t.Optional[t.Tuple[int]] = None):
+            font_sizes: t.Optional[t.Tuple[int, ...]] = None):
         self._width = width
         self._height = height
         self._fonts = fonts or DEFAULT_FONTS


### PR DESCRIPTION
typing of the font_sizes in image captcha was set to a Tuple with one int value which I changed to Tuple of int values